### PR TITLE
:sparkles: [pytest] Randomize test order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,11 @@ all: test quality
 
 .PHONY: test
 test:
+	poetry run coverage run --module pytest --random-order
+	poetry run coverage report
+
+.PHONY: test-ordered
+test-ordered:
 	poetry run coverage run --module pytest
 	poetry run coverage report
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -827,6 +827,21 @@ docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1)"]
 testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
 
 [[package]]
+name = "pytest-random-order"
+version = "1.1.1"
+description = "Randomise the order in which pytest tests are run with some control over the randomness"
+optional = false
+python-versions = ">=3.5.0"
+groups = ["dev"]
+files = [
+    {file = "pytest-random-order-1.1.1.tar.gz", hash = "sha256:4472d7d34f1f1c5f3a359c4ffc5c13ed065232f31eca19c8844c1ab406e79080"},
+    {file = "pytest_random_order-1.1.1-py3-none-any.whl", hash = "sha256:882727a8b597ecd06ede28654ffeb8a6d511a1e4abe1054cca7982f2e42008cd"},
+]
+
+[package.dependencies]
+pytest = ">=3.0.0"
+
+[[package]]
 name = "pytest-socket"
 version = "0.7.0"
 description = "Pytest Plugin to disable socket calls during tests"
@@ -952,4 +967,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "0333c0a97b260a99731583e2b3b63650f71c51b65b92307dd23a67eea7211613"
+content-hash = "2cfaa72c9874b6147dd373997f5ae6e4237f7a2256631deafaeb5758f2e4e0ea"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ pre-commit = ">=3.8.0"
 pylint = ">=3.2.7"
 pytest = ">=8.3.2"
 pytest-asyncio = ">=0.24.0"
+pytest-random-order = ">=1.1.1"
 pytest-socket = ">=0.7.0"
 
 [tool.black]


### PR DESCRIPTION
Problem:
- Tests should be able to be run in any order. Always running them in the same order potentially hides issues around test ordering.